### PR TITLE
Update Linter configuration and fix all linting errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,17 @@
         "sourceType": "module"
     },
     "rules": {
+        "require-jsdoc": ["error", {
+            "require": {
+                "FunctionDeclaration": false,
+                "MethodDefinition": false,
+                "ClassDeclaration": false,
+                "ArrowFunctionExpression": false,
+                "FunctionExpression": false
+            }
+        }],
+        "max-len": ["error", {
+            "code": 100
+        }]
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Coming soon!
 ## Developer setup
 
 Run these in the root of the repo:
-* `npm install`
-* 
+* `$ npm install`
+* Create a new file `.git/hooks/pre-commit` and paste this code inside it:
 ```
-echo '#!/bin/bash
+#!/bin/bash
 # From https://gist.github.com/dahjelle/8ddedf0aebd488208a9a7c829f19b9e8
 for file in $(git diff --cached --name-only | grep -E '\.(js|jsx)$')
 do
@@ -57,16 +57,16 @@ do
     echo "ESLint failed on staged file '$file'. Please check your code and try again. You can run ESLint manually via npm run eslint."
     exit 1 # exit with failure status
   fi
-done' > .git/hooks/pre-commit
+done
 ```
 
-* `chmod +x .git/hooks/pre-commit`
+* `$ chmod +x .git/hooks/pre-commit`
 
 
 
 ## Database setup
 
 1. change the connection string in main.js
-2. run create table users(username varchar(255), password varchar(255), premium bool);
+2. run `create table users(username varchar(255), password varchar(255), premium bool);`
 
 Note: need to add more field to DB for player status

--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ const PORT = process.env.PORT || 5000;
 // //////////////////
 // Lang: Have set conncetion on db inside function
 // lang local test
-var pg = require('pg');
-var conString = "postgres://vyqzrennssqgdm:5427cde89c19c7c04595851cca03f048cce351ed5ce02df1f19e4ff075effa20@ec2-174-129-253-162.compute-1.amazonaws.com:5432/dchmahd956dtm0?ssl=true";
-///////////////////
-
+const pg = require('pg');
+// eslint-disable-next-line max-len
+const conString = 'postgres://vyqzrennssqgdm:5427cde89c19c7c04595851cca03f048cce351ed5ce02df1f19e4ff075effa20@ec2-174-129-253-162.compute-1.amazonaws.com:5432/dchmahd956dtm0?ssl=true';
+// /////////////////
 
 
 const app = express();
@@ -23,11 +23,11 @@ app.set('view engine', 'ejs');
 // app.get('/', function(req, res) {
 //   res.sendFile(path.join(path.join(__dirname, 'public'), 'login.html'));
 // });
-app.get('/', (req, res) => res.render('pages/login'))
-app.get('/register', (req, res) => res.render('pages/register'))
-app.get('/login', (req, res) => res.render('pages/login'))
-app.get('/main', (req, res) => res.render('pages/levels/main'))
-app.get('/bb-test', (req, res) => res.render('pages/levels/bb-test'))
+app.get('/', (req, res) => res.render('pages/login'));
+app.get('/register', (req, res) => res.render('pages/register'));
+app.get('/login', (req, res) => res.render('pages/login'));
+app.get('/main', (req, res) => res.render('pages/levels/main'));
+app.get('/bb-test', (req, res) => res.render('pages/levels/bb-test'));
 
 app.post('/login', (req, res) => checklogin(req, res));
 app.post('/register', (req, res) => createlogin(req, res));
@@ -99,7 +99,8 @@ function checklogin(req, res) {
           if (result.rows.length<1 ) {
             console.log('password incorrect or account not exist!');
             res.status(404).redirect('back');
-          } else if (result.rows[0].password === loginpsw) { // account exist and psw correct
+          } else if (result.rows[0].password === loginpsw) {
+            // account exist and psw correct
             console.log(result.rows[0].premium);
             if (result.rows[0].premium) {
               res.status(200).redirect('/main?premium=true');

--- a/public/scripts/BoundingBox.js
+++ b/public/scripts/BoundingBox.js
@@ -1,4 +1,4 @@
-import {DegreesToRadians} from './helper_functions.js';
+import {degreesToRadians} from './helper_functions.js';
 
 export class BoundingBox {
   constructor(group, shape, isVisible) {
@@ -51,8 +51,10 @@ export class VisionCone {
       points: [
         this.startPoints.x,
         this.startPoints.y,
-        this.startPoints.x + this.cone.getAttr('radius') * Math.cos( DegreesToRadians(this.cone.getAttr('rotation')) ),
-        this.startPoints.y + this.cone.getAttr('radius') * Math.sin( DegreesToRadians(this.cone.getAttr('rotation')) ),
+        this.startPoints.x +
+          this.cone.getAttr('radius') * Math.cos( degreesToRadians(this.cone.getAttr('rotation')) ),
+        this.startPoints.y +
+          this.cone.getAttr('radius') * Math.sin( degreesToRadians(this.cone.getAttr('rotation')) ),
       ],
       stroke: 'red',
       strokeWidth: 4,
@@ -62,8 +64,12 @@ export class VisionCone {
       points: [
         this.startPoints.x,
         this.startPoints.y,
-        this.startPoints.x + this.cone.getAttr('radius') * Math.cos( DegreesToRadians(this.cone.getAttr('rotation') + this.cone.getAttr('angle')/2) ),
-        this.startPoints.y + this.cone.getAttr('radius') * Math.sin( DegreesToRadians(this.cone.getAttr('rotation') + this.cone.getAttr('angle')/2) ),
+        this.startPoints.x +
+          this.cone.getAttr('radius') * Math.cos( degreesToRadians(this.cone.getAttr('rotation') +
+          this.cone.getAttr('angle')/2) ),
+        this.startPoints.y +
+          this.cone.getAttr('radius') * Math.sin( degreesToRadians(this.cone.getAttr('rotation') +
+          this.cone.getAttr('angle')/2) ),
       ],
       stroke: 'red',
       strokeWidth: 4,
@@ -73,8 +79,12 @@ export class VisionCone {
       points: [
         this.startPoints.x,
         this.startPoints.y,
-        this.startPoints.x + this.cone.getAttr('radius') * Math.cos( DegreesToRadians(this.cone.getAttr('rotation') + this.cone.getAttr('angle')) ),
-        this.startPoints.y + this.cone.getAttr('radius') * Math.sin( DegreesToRadians(this.cone.getAttr('rotation') + this.cone.getAttr('angle')) ),
+        this.startPoints.x +
+          this.cone.getAttr('radius') * Math.cos( degreesToRadians(this.cone.getAttr('rotation') +
+          this.cone.getAttr('angle')) ),
+        this.startPoints.y +
+          this.cone.getAttr('radius') * Math.sin( degreesToRadians(this.cone.getAttr('rotation') +
+          this.cone.getAttr('angle')) ),
       ],
       stroke: 'red',
       strokeWidth: 4,

--- a/public/scripts/Entity.js
+++ b/public/scripts/Entity.js
@@ -10,8 +10,8 @@ export class Entity {
     this.y = data.y;
     this.id = genID();
 
+    let imageObj;
     if (data.image) {
-      var imageObj;
       const promise = loadImage(data.image);
       promise.then(function(result) {
         // console.log(result);

--- a/public/scripts/helper_functions.js
+++ b/public/scripts/helper_functions.js
@@ -31,10 +31,10 @@ export async function loadImage(imageUrl) {
   return img;
 }
 
-export function DegreesToRadians(degree) {
+export function degreesToRadians(degree) {
   return degree * Math.PI/180;
 }
 
-export function RadiansToDegrees(radians) {
+export function radiansToDegrees(radians) {
   return radians * 180/Math.PI;
 }

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -77,29 +77,29 @@ layer.add(endPoint.render);
 
 // Tooltip for completing level
 const completionTooltip = new Konva.Text({
-    x: stage.width() - 400,
-    y: 0,
-    text: 'E/SPACE\nTO COMPLETE LEVEL',
-    fontSize: 18,
-    fill: '#555',
-    padding: 20,
-    align: 'center',
+  x: stage.width() - 400,
+  y: 0,
+  text: 'E/SPACE\nTO COMPLETE LEVEL',
+  fontSize: 18,
+  fill: '#555',
+  padding: 20,
+  align: 'center',
 });
 
 const completionTooltipBox = new Konva.Rect({
-    x: stage.width() - 400,
-    y: 0,
-    stroke: '#555',
-    strokeWidth: 5,
-    fill: '#ddd',
-    width: 240,
-    height: completionTooltip.height(),
-    shadowColor: 'black',
-    shadowBlur: 10,
-    shadowOffsetX: 10,
-    shadowOffsetY: 10,
-    shadowOpacity: 0.2,
-    cornerRadius: 10,
+  x: stage.width() - 400,
+  y: 0,
+  stroke: '#555',
+  strokeWidth: 5,
+  fill: '#ddd',
+  width: 240,
+  height: completionTooltip.height(),
+  shadowColor: 'black',
+  shadowBlur: 10,
+  shadowOffsetX: 10,
+  shadowOffsetY: 10,
+  shadowOpacity: 0.2,
+  cornerRadius: 10,
 });
 
 
@@ -311,16 +311,15 @@ container.addEventListener('keydown', function(event) {
         atEndPoint = true;
         layer.add(completionTooltipBox);
         layer.add(completionTooltip);
-        layer.draw()
+        layer.draw();
       } else {
         // console.log('i am not sure where i am...', node.id);
         // console.log(node.name);
       }
-    }
-    else {
-        atEndPoint = false;
-        completionTooltipBox.remove();
-        completionTooltip.remove();
+    } else {
+      atEndPoint = false;
+      completionTooltipBox.remove();
+      completionTooltip.remove();
     }
   });
 
@@ -353,15 +352,13 @@ function doKeyProcess(keys) {
   // Space or E for interaction
   if (keys[32] || keys[69]) {
     if (atEndPoint) {
-        alert('YOU WIN! Play again?');
-        location.reload();
-    }
-    else if (inFightScene) {
-        fightLayer.remove();
-        stage.add(layer);
-        inFightScene = false;
-    }
-    else if (readyToInteract) {
+      alert('YOU WIN! Play again?');
+      location.reload();
+    } else if (inFightScene) {
+      fightLayer.remove();
+      stage.add(layer);
+      inFightScene = false;
+    } else if (readyToInteract) {
       layer.remove();
       stage.add(fightLayer);
       inFightScene = true;


### PR DESCRIPTION
Modified two rules of the existing linter:
* Removed jsdoc requirement (lets be honest, we're not going to document our classes per-method)
* Max length of lines extended from 80 to 100.

The README.md has also been updated slightly to fix a bug with the pre-commit hook script. Everyone should update their `.git/hooks/pre-commit` scripts to match the README now.

Included in this are all the required code changes to have the linter 100% pass. Any future work on the repo should now use the precommit hook that runs eslint.