### PR TITLE
specify max_face_length, comment on forked web service

### DIFF
--- a/public/scripts/Character.js
+++ b/public/scripts/Character.js
@@ -8,8 +8,9 @@ export class Character extends Entity {
     super(data);
     this.speed = 5; // movement speed
     this.enableFace = (data.enableFace) ? data.enableFace : false;
-    // Draw a face using cool-ascii-faces API
-    const text = httpGet('https://fathomless-temple-39382.herokuapp.com/');
+    // Draw a face using fork off cool-ascii-faces web service
+    // https://github.com/abhatthal/cool-face-service
+    const text = httpGet('https://fathomless-temple-39382.herokuapp.com/?max_face_length=10');
     this.face = new Konva.Text({
       x: -18,
       y: -10,


### PR DESCRIPTION
Using my own API now, based off cool-ascii-faces

Since we need to have a separate project for our API criteria,
here is the API project: https://github.com/abhatthal/cool-face-service
It takes a single optional parameter of max_face_length,
it defaults to using the entire array of ascii faces.